### PR TITLE
Increase PWM_GRAD to 6. (Stabilize amplitude faster when accelerating…

### DIFF
--- a/MM-control-01/tmc2130.c
+++ b/MM-control-01/tmc2130.c
@@ -207,8 +207,8 @@ int8_t tmc2130_init_axis_current_stealth(uint8_t axis, uint8_t current_h, uint8_
 	tmc2130_wr(axis, TMC2130_REG_COOLCONF, (((uint32_t)TMC2130_SG_THR) << 16));
 	tmc2130_wr(axis, TMC2130_REG_TCOOLTHRS, 0);
 	tmc2130_wr(axis, TMC2130_REG_GCONF, 0x00000004);
-	tmc2130_wr_PWMCONF(axis, 4 * current_r, 2, 2, 1, 0, 0);
-	tmc2130_wr_TPWMTHRS(axis, 0);
+	tmc2130_wr_PWMCONF(axis, 210, 6, 2, 1, 0, 0);
+	tmc2130_wr_TPWMTHRS(axis, 200);
 	return 0;
 }
 


### PR DESCRIPTION
….) Set PWM_AMPL to 210. User   defined maximum PWM amplitude when switching back from current chopper mode to voltage PWM  mode. This value is tailored to 12V power supply, needs to verified for 24V. Set transition speed TPWMTHRS to 200 (fOSC/256/200 = 13MHz / 256 / 200 = 254 Hz full step rate) (switch from stealthChop to spreadCycle). Verified for 24V - there is 150 mA current overshot during switch, which is acceptable - target current is 650 mA it overshots to 800 mA, but motor allowed current is 1000 mA.